### PR TITLE
Allowing every types of key_id. 

### DIFF
--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -40,7 +40,7 @@ class NotificationsModule extends Module
      * @param Notification $notification The notification class
      * @param string $key The notification key
      * @param integer $user_id The user id that will get the notification
-     * @param integer $key_id The key unique id
+     * @param string $key_id The key unique id
      * @param string $type The notification type
      * @return bool Returns TRUE on success, FALSE on failure
      * @throws Exception
@@ -57,14 +57,14 @@ class NotificationsModule extends Module
         }
 
         /** @var Notification $instance */
-        $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => $key_id]);
+        $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
         if (!$instance) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,
                 'seen' => 0,
                 'user_id' => $user_id,
-                'key_id' => $key_id,
+                'key_id' => (string)$key_id,
                 'created_at' => new Expression('NOW()'),
             ]);
             return $instance->save();

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -63,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance || self->allowDuplicateNotifications) {
+        if (!$instance || Yii::$app->getModule('notifications')->allowDuplicateNotifications) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -20,6 +20,11 @@ class NotificationsModule extends Module
     public $notificationClass;
 
     /**
+    * @var boolean Define wether notification can be duplicated (same user_id, key, and key_id) or not.
+    */
+    public $allowDuplicateNotifications = false;
+
+    /**
      * @var callable|integer The current user id
      */
     public $userId;
@@ -58,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance) {
+        if (!$instance || $this->allowDuplicateNotifications)) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -63,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance || Yii::$app->getModule('notifications')->allowDuplicateNotifications) {
+        if (!$instance || self::getInstance()->allowDuplicateNotifications) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -63,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance || self::getInstance()->allowDuplicateNotifications) {
+        if (!$instance || \Yii::$app->getModule('notifications')->allowDuplicateNotifications) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -22,7 +22,7 @@ class NotificationsModule extends Module
     /**
     * @var boolean Define wether notification can be duplicated (same user_id, key, and key_id) or not.
     */
-    public static $allowDuplicateNotifications = false;
+    public $allowDuplicateNotifications = false;
 
     /**
      * @var callable|integer The current user id
@@ -63,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance || self::$allowDuplicateNotifications) {
+        if (!$instance || self->allowDuplicateNotifications) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -25,6 +25,11 @@ class NotificationsModule extends Module
     public $userId;
 
     /**
+     * @var boolean Define wether notification can be duplicated (same user_id, key, and key_id) or not.
+     */
+    public $allowDuplicateNotifications = false;
+
+    /**
      * @inheritdoc
      */
     public function init() {
@@ -58,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => (string)$key_id]);
-        if (!$instance) {
+        if (!$instance || $this->allowDuplicateNotifications) {
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,6 +17,9 @@ return [
             // Point this to your own Notification class
             // See the "Declaring your notifications" section below
             'notificationClass' => 'app\models\Notification',
+            // Allows to have notification with same (user_id, key, key_id)
+            // 'allowDuplicateNotifications' => false,
+
             // This callable should return your logged in user Id
             'userId' => function() {
                 return \Yii::$app->user->id;
@@ -76,7 +79,7 @@ class Notification extends BaseNotification
 
             case self::KEY_NEW_MESSAGE:
                 return Yii::t('app', 'You got a new message');
-                
+
             case self::KEY_NO_DISK_SPACE:
                 return Yii::t('app', 'No disk space left');
         }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,6 +17,8 @@ return [
             // Point this to your own Notification class
             // See the "Declaring your notifications" section below
             'notificationClass' => 'app\models\Notification',
+            // Allows to have notification with same (user_id, key, key_id)
+            'allowDuplicateNotifications' => false,
             // This callable should return your logged in user Id
             'userId' => function() {
                 return \Yii::$app->user->id;
@@ -76,7 +78,7 @@ class Notification extends BaseNotification
 
             case self::KEY_NEW_MESSAGE:
                 return Yii::t('app', 'You got a new message');
-                
+
             case self::KEY_NO_DISK_SPACE:
                 return Yii::t('app', 'No disk space left');
         }

--- a/migrations/m151008_162401_create_notification_table.php
+++ b/migrations/m151008_162401_create_notification_table.php
@@ -5,7 +5,7 @@ use yii\db\Migration;
 class m151008_162401_create_notification_table extends Migration
 {
     const TABLE_NAME = '{{%notification}}';
-    
+
     public function up()
     {
         $this->createTable(self::TABLE_NAME, [

--- a/migrations/m160921_171124_alter_notification_table.php
+++ b/migrations/m160921_171124_alter_notification_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use yii\db\Migration;
+
+class m160921_171124_alter_notification_table extends Migration
+{
+    const TABLE_NAME = '{{%notification}}';
+
+    public function up()
+    {
+        $this->alterColumn(self::TABLE_NAME, 'key_id', 'string');
+    }
+
+    public function down()
+    {
+        $this->dropTable(self::TABLE_NAME);
+    }
+}

--- a/models/Notification.php
+++ b/models/Notification.php
@@ -10,7 +10,7 @@ use yii\db\ActiveRecord;
  * This is the model class for table "notification".
  *
  * @property integer $id
- * @property integer $key_id
+ * @property string $key_id
  * @property string $key
  * @property string $type
  * @property boolean $seen
@@ -84,7 +84,8 @@ abstract class Notification extends ActiveRecord
         return [
             [['type', 'user_id', 'key', 'created_at'], 'required'],
             [['id', 'key_id', 'created_at'], 'safe'],
-            [['key_id', 'user_id'], 'integer'],
+            [['user_id'], 'integer'],
+            [['key_id'], 'string'],
         ];
     }
 
@@ -93,7 +94,7 @@ abstract class Notification extends ActiveRecord
      *
      * @param string $key
      * @param integer $user_id The user id that will get the notification
-     * @param integer $key_id The foreign instance id
+     * @param string $key_id The foreign instance id
      * @param string $type
      * @return bool Returns TRUE on success, FALSE on failure
      * @throws \Exception
@@ -109,7 +110,7 @@ abstract class Notification extends ActiveRecord
      *
      * @param string $key
      * @param integer $user_id The user id that will get the notification
-     * @param integer $key_id The notification key id
+     * @param string $key_id The notification key id
      * @return bool Returns TRUE on success, FALSE on failure
      */
     public static function warning($key, $user_id, $key_id = null)
@@ -123,7 +124,7 @@ abstract class Notification extends ActiveRecord
      *
      * @param string $key
      * @param integer $user_id The user id that will get the notification
-     * @param integer $key_id The notification key id
+     * @param string $key_id The notification key id
      * @return bool Returns TRUE on success, FALSE on failure
      */
     public static function error($key, $user_id, $key_id = null)
@@ -137,7 +138,7 @@ abstract class Notification extends ActiveRecord
      *
      * @param string $key
      * @param integer $user_id The user id that will get the notification
-     * @param integer $key_id The notification key id
+     * @param string $key_id The notification key id
      * @return bool Returns TRUE on success, FALSE on failure
      */
     public static function success($key, $user_id, $key_id = null)
@@ -146,4 +147,3 @@ abstract class Notification extends ActiveRecord
     }
 
 }
-


### PR DESCRIPTION
This update provides the ability to have several types of key_id (such as string for example).

Example: if i have a Post class with a string id like "57e253dd7fdb4" (uniqid). With the actual version of the module , i can't save a new notification with "57e253dd7fdb4" in key_id.

With this update, you can have both integer id or string id.

Thanks in advance.