### PR TITLE
Adding ability to duplicate notification if needed.

### DIFF
--- a/NotificationsModule.php
+++ b/NotificationsModule.php
@@ -20,6 +20,11 @@ class NotificationsModule extends Module
     public $notificationClass;
 
     /**
+    * @var boolean Define wether notification can be duplicated (same user_id, key, and key_id) or not.
+    */
+    public $allowDuplicateNotifications = false;
+
+    /**
      * @var callable|integer The current user id
      */
     public $userId;
@@ -58,7 +63,7 @@ class NotificationsModule extends Module
 
         /** @var Notification $instance */
         $instance = $notification::findOne(['user_id' => $user_id, 'key' => $key, 'key_id' => $key_id]);
-        if (!$instance) {
+        if (!$instance || \Yii::$app->getModule('notifications')->allowDuplicateNotifications) 
             $instance = new $notification([
                 'key' => $key,
                 'type' => $type,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -17,6 +17,9 @@ return [
             // Point this to your own Notification class
             // See the "Declaring your notifications" section below
             'notificationClass' => 'app\models\Notification',
+            // Allows to have notification with same (user_id, key, key_id)
+            // 'allowDuplicateNotifications' => false,
+            
             // This callable should return your logged in user Id
             'userId' => function() {
                 return \Yii::$app->user->id;
@@ -76,7 +79,7 @@ class Notification extends BaseNotification
 
             case self::KEY_NEW_MESSAGE:
                 return Yii::t('app', 'You got a new message');
-                
+
             case self::KEY_NO_DISK_SPACE:
                 return Yii::t('app', 'No disk space left');
         }


### PR DESCRIPTION
Allows the module to have duplicated notifications (user_id, key, key_id)

Example :
If i have workflow validation on a model. We have to notify concerned users. If the object is refused, another notification will be created and assign to the object creator. After modify the object to be in phase with the validation, he will ask for a new validation on the same object. In this case the notification will be the same as the first one. The module as is actually done does not permit the behavior... So i propose an update that allows it. We just have to specify in the config if we want to allow duplicate notification.

Thanks.