### PR TITLE
Ability to change item tag

### DIFF
--- a/assets/notifications.js
+++ b/assets/notifications.js
@@ -175,6 +175,7 @@ var Notifications = (function(options) {
         markAllSeenSelector: null,
         deleteAllSelector: null,
         listSelector: null,
+        tag: "<div>",
         listItemTemplate:
             '<div class="row">' +
                 '<div class="col-xs-10">' +
@@ -205,13 +206,18 @@ var Notifications = (function(options) {
      */
     this.renderRow = function (object) {
         var keywords = ['id', 'title', 'description', 'url', 'type'];
-        var ret, html = self.opts.listItemTemplate;
+        var ret, html;
 
-        html = '<div class="notification notification-{type} ' +
-            (object.seen ? 'notification-seen' : 'notification-unseen') +
-            '" data-route="{url}" data-id="{id}">' +
-                html +
-                '</div>';
+         html = $(self.opts.tag, {
+            class: "notification notification-" + object['type'] + " "+(object.seen ? 'notification-seen' : 'notification-unseen'),
+            data: {
+                route: object['url'],
+                id: object['id']
+            },
+            html: self.opts.listItemTemplate
+        })[0].outerHTML;
+        
+        
 
         for (var i = 0; i < keywords.length; i++) {
             html = html.replace(new RegExp('{' + keywords[i] + '}', 'g'), object[keywords[i]]);

--- a/assets/notifications.js
+++ b/assets/notifications.js
@@ -205,7 +205,7 @@ var Notifications = (function(options) {
      * @returns {jQuery|HTMLElement|*}
      */
     this.renderRow = function (object) {
-        var keywords = ['id', 'title', 'description', 'url', 'type'];
+        var keywords = ['title', 'description', 'url'];
         var ret, html;
 
          html = $(self.opts.tag, {

--- a/assets/notifications.js
+++ b/assets/notifications.js
@@ -231,8 +231,10 @@ var Notifications = (function(options) {
 
             // Update all counters
             for (var i = 0; i < self.opts.counters.length; i++) {
-                if ($(self.opts.counters[i]).text() != parseInt($(self.opts.counters[i]).html())-1) {
-                    $(self.opts.counters[i]).text(parseInt($(self.opts.counters[i]).html())-1);
+                var currentCounter = $(self.opts.counters[i]),
+                    targetCount = parseInt(currentCounter.html()) - 1;
+                if (currentCounter.text() != targetCount) {
+                    currentCounter.text(targetCount || "");
                 }
             }
 
@@ -352,8 +354,9 @@ var Notifications = (function(options) {
 
                 // Update all counters
                 for (var i = 0; i < self.opts.counters.length; i++) {
-                    if ($(self.opts.counters[i]).text() != data.length) {
-                        $(self.opts.counters[i]).text(data.length);
+                    var counter=$(self.opts.counters[i]);
+                    if (counter.text() != data.length) {
+                        counter.text(data.length || "");
                     }
                 }
 

--- a/assets/notifications.js
+++ b/assets/notifications.js
@@ -210,10 +210,8 @@ var Notifications = (function(options) {
 
          html = $(self.opts.tag, {
             class: "notification notification-" + object['type'] + " "+(object.seen ? 'notification-seen' : 'notification-unseen'),
-            data: {
-                route: object['url'],
-                id: object['id']
-            },
+            "data-route":object['url'],
+            "data-id":object['id'],
             html: self.opts.listItemTemplate
         })[0].outerHTML;
         

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -85,6 +85,7 @@ NotificationsWidget::widget([
 | listSelector         | A jQuery selector for your UI element that will holds the notification list | null        |
 | listItemTemplate     | An optional template for the list item.                                     | built-in    |
 | listItemBeforeRender | An optional callback to tweak the list item layout before rendering         | empty cb    |
+| tag                  | The name of the tag used for each notification                              | 'div'       |
 
 
 Supported libraries

--- a/widgets/NotificationsWidget.php
+++ b/widgets/NotificationsWidget.php
@@ -133,6 +133,11 @@ class NotificationsWidget extends Widget
     public $listSelector = null;
 
     /**
+     * @var string The wrapper tag for each item
+     */
+    public $tag = "div";
+    
+    /**
      * @var string The list item HTML template
      */
     public $listItemTemplate = null;
@@ -205,6 +210,7 @@ class NotificationsWidget extends Widget
             'pollSeen' => !!$this->pollSeen,
             'pollInterval' => Html::encode($this->pollInterval),
             'counters' => $this->counters,
+            'tag' => Html::beginTag($this->tag)
         ];
 
         if ($this->theme) {


### PR DESCRIPTION
With this modification user can change the name of the tag used to wrap the notification.
It is an optional parameter in order to keep BC.

Also there is another _little tweak_. When there aren´t notifications counters now displays nothing instead 0. 

This allows the user **hide a badge** when there are not notifications by using `:empty` css property.
If you need to keep 0 number then use css rule `.counterclass:empty:before { content: "0"}`

The behavior of hiding a badge when it is empty is used by almost all admin templates.