### PR TITLE
Set Correct Time for Notification Using Application's Timezone

### DIFF
--- a/controllers/NotificationsController.php
+++ b/controllers/NotificationsController.php
@@ -56,7 +56,8 @@ class NotificationsController extends Controller
         foreach ($models as $model) {
 
             // give user a chance to parse the date as needed
-            $date = \DateTime::createFromFormat($this->module->dbDateFormat, $model->created_at)
+            $date = \DateTime::createFromFormat($this->module->dbDateFormat, $model->created_at, new \DateTimeZone('UTC'))
+                ->setTimezone(new \DateTimeZone(\Yii::$app->timezone))
                 ->format('Y-m-d H:i:s');
 
             /** @var Notification $model */


### PR DESCRIPTION
Related [issue](https://github.com/machour/yii2-notifications/issues/53).

This fix uses 'UTC' as third parameter for `createFromFormat` and then sets the timezone to application's timezone. This way, notifications' time will be correct if user is from another timezone than UTC.